### PR TITLE
feat: initialize client as part of `ImageKit` instance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
@@ -259,6 +265,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-auth-basic"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2e17aacf7f4a2428def798e2ff4f4f883c0987bdaf47dd5c8bc027bc9f1ebc"
+dependencies = [
+ "base64 0.13.1",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,6 +362,7 @@ version = "0.1.0-beta+1"
 dependencies = [
  "anyhow",
  "async-trait",
+ "http-auth-basic",
  "reqwest",
  "serde",
  "serde_json",
@@ -602,7 +618,7 @@ version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ba30cc2c0cd02af1222ed216ba659cdb2f879dfe3181852fe7c50b1d0005949"
 dependencies = [
- "base64",
+ "base64 0.21.0",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -688,7 +704,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
- "base64",
+ "base64 0.21.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ rustls-tls = ["reqwest/rustls-tls"]
 [dependencies]
 anyhow = "1.0.58"
 async-trait = "0.1.56"
+http-auth-basic = "0.3.3"
 reqwest = { version = "0.11.15", features = ["json", "multipart", "stream"], default_features = false }
 serde = { version = "1.0.138", features = ["derive"] }
 serde_json = "1.0.82"

--- a/src/client.rs
+++ b/src/client.rs
@@ -24,6 +24,7 @@ pub const FILES_ENDPOINT: &str = "https://api.imagekit.io/v1/files";
 pub struct ImageKit {
     #[allow(dead_code)]
     pub(crate) public_key: String,
+    #[allow(dead_code)]
     pub(crate) private_key: String,
     #[allow(dead_code)]
     pub(crate) url_endpoint: String,

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,9 +1,11 @@
-use anyhow::{bail, Result};
-use reqwest::Client;
 use std::env::var;
 
+use anyhow::{bail, Result};
+use http_auth_basic::Credentials;
+use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION};
+use reqwest::{Client, ClientBuilder};
+
 pub const FILES_ENDPOINT: &str = "https://api.imagekit.io/v1/files";
-pub const UPLOAD_ENDPOINT: &str = "https://upload.imagekit.io/api/v1/files/upload";
 
 /// An ImageKit.io API Client Instance
 ///
@@ -20,7 +22,6 @@ pub const UPLOAD_ENDPOINT: &str = "https://upload.imagekit.io/api/v1/files/uploa
 /// If you want to set a custom upload endpoint, you can use the
 /// `upload_endpoint` method.
 pub struct ImageKit {
-    pub(crate) upload_endpoint: String,
     #[allow(dead_code)]
     pub(crate) public_key: String,
     pub(crate) private_key: String,
@@ -31,10 +32,17 @@ pub struct ImageKit {
 
 impl ImageKit {
     pub fn new<T: ToString>(public_key: T, private_key: T, url_endpoint: T) -> Self {
-        let client = Client::new();
+        let creds = Credentials::new(&private_key.to_string(), "").as_http_header();
+        let mut headers = HeaderMap::new();
+
+        headers.insert(AUTHORIZATION, HeaderValue::from_str(&creds).unwrap());
+
+        let client = ClientBuilder::new()
+            .default_headers(headers)
+            .build()
+            .unwrap();
 
         Self {
-            upload_endpoint: UPLOAD_ENDPOINT.to_string(),
             public_key: public_key.to_string(),
             private_key: private_key.to_string(),
             url_endpoint: url_endpoint.to_string(),
@@ -56,46 +64,5 @@ impl ImageKit {
             Ok(value) => Ok(value),
             Err(err) => bail!(err),
         }
-    }
-
-    /// Returns a mutable reference to the `upload_endpoint` used by this
-    /// ImageKit client instance. Can be used to update the instance value
-    /// or retrieve the value.
-    ///
-    /// ```
-    /// use imagekit::client::ImageKit;
-    ///
-    /// let mut image_kit = ImageKit::new(
-    ///    "your_public_api_key",
-    ///    "your_private_api_key",
-    ///    "https://ik.imagekit.io/your_imagekit_id/",
-    /// );
-    /// let new_endpoint = String::from("https://upload.example.com/api/v1/files/upload");
-    ///
-    /// *image_kit.upload_endpoint() = new_endpoint.clone();
-    ///
-    /// assert_eq!(image_kit.upload_endpoint().to_owned(), new_endpoint);
-    /// ```
-    pub fn upload_endpoint(&mut self) -> &mut String {
-        &mut self.upload_endpoint
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::ImageKit;
-
-    #[test]
-    fn updates_the_upload_endpoint() {
-        let mut image_kit = ImageKit::new(
-            "your_public_api_key",
-            "your_private_api_key",
-            "https://ik.imagekit.io/your_imagekit_id/",
-        );
-        let new_endpoint = String::from("https://upload.example.com/api/v1/files/upload");
-
-        *image_kit.upload_endpoint() = new_endpoint.clone();
-
-        assert_eq!(image_kit.upload_endpoint, new_endpoint);
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -32,30 +32,27 @@ pub struct ImageKit {
 }
 
 impl ImageKit {
-    pub fn new<T: ToString>(public_key: T, private_key: T, url_endpoint: T) -> Self {
+    pub fn new<T: ToString>(public_key: T, private_key: T, url_endpoint: T) -> Result<Self> {
         let creds = Credentials::new(&private_key.to_string(), "").as_http_header();
         let mut headers = HeaderMap::new();
 
-        headers.insert(AUTHORIZATION, HeaderValue::from_str(&creds).unwrap());
+        headers.insert(AUTHORIZATION, HeaderValue::from_str(&creds)?);
 
-        let client = ClientBuilder::new()
-            .default_headers(headers)
-            .build()
-            .unwrap();
+        let client = ClientBuilder::new().default_headers(headers).build()?;
 
-        Self {
+        Ok(Self {
             public_key: public_key.to_string(),
             private_key: private_key.to_string(),
             url_endpoint: url_endpoint.to_string(),
             client,
-        }
+        })
     }
 
     pub fn from_env() -> Result<Self> {
         let public_key = ImageKit::env("IMAGEKIT_PUBLIC_KEY")?;
         let private_key = ImageKit::env("IMAGEKIT_PRIVATE_KEY")?;
         let url_endpoint = ImageKit::env("IMAGEKIT_URL_ENDPOINT")?;
-        let imagekit = Self::new(public_key, private_key, url_endpoint);
+        let imagekit = Self::new(public_key, private_key, url_endpoint)?;
 
         Ok(imagekit)
     }

--- a/src/delete/mod.rs
+++ b/src/delete/mod.rs
@@ -16,14 +16,7 @@ impl Delete for ImageKit {
     async fn delete<T: ToString + Send>(&self, file_id: T) -> Result<()> {
         let url_string = format!("{}/{}", FILES_ENDPOINT, file_id.to_string());
         let endpoint_url = Url::parse(&url_string).unwrap();
-        let private_key = self.private_key.to_owned();
-        let response = self
-            .client
-            .delete(endpoint_url)
-            .basic_auth::<String, String>(private_key, None)
-            .send()
-            .await
-            .unwrap();
+        let response = self.client.delete(endpoint_url).send().await.unwrap();
 
         if matches!(response.status(), StatusCode::NO_CONTENT) {
             return Ok(());


### PR DESCRIPTION
Credentials will now be internally provided when creating a `ImageKit` client instance.

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
